### PR TITLE
Updated the quotes to make better use of markdown

### DIFF
--- a/quotes/alan_kay.md
+++ b/quotes/alan_kay.md
@@ -1,13 +1,16 @@
-A change in perspective is worth 80 IQ points.
+> A change in perspective is worth 80 IQ points.
+>
+> &mdash; https://www.folklore.org/StoryView.py?project=Macintosh&story=Creative_Think.txt, 1982-07-20
 
-[1982-07-20,
-https://www.folklore.org/StoryView.py?project=Macintosh&story=Creative_Think.txt]
+---
 
-Technology is anything that wasn't around when you were born.
+> Technology is anything that wasn't around when you were born.
+>
+> &mdash; Hong Kong press conference in the late 1980s, 1980
 
-[1980, Hong Kong press conference in the late 1980s]
+---
 
-Actually I made up the term "object-oriented", and I can tell you I did not have
-C++ in mind.
-
-[1997, https://www.youtube.com/watch?v=oKg1hTOQXoY]
+> Actually I made up the term "object-oriented", and I can tell you I did not have
+> C++ in mind.
+>
+> &mdash; https://www.youtube.com/watch?v=oKg1hTOQXoY, 1997

--- a/quotes/bjarne_stroustrup.md
+++ b/quotes/bjarne_stroustrup.md
@@ -1,32 +1,44 @@
-Proof by analogy is fraud.
+> Proof by analogy is fraud.
+>
+> &mdash; The C++ Programming Language. pp. 692
 
-[The C++ Programming Language. pp. 692]
+---
 
-A program that has not been tested does not work.
+> A program that has not been tested does not work.
+>
+> &mdash; The C++ Programming Language. pp. 712
 
-[The C++ Programming Language. pp. 712]
+---
 
-"How to test?" is a question that cannot be answered in general. "When to test?"
-however, does have a general answer: as early and as often as possible.
+> "How to test?" is a question that cannot be answered in general. "When to test?"
+> however, does have a general answer: as early and as often as possible.
+>
+> &mdash; The C++ Programming Language. pp. 712
 
-[The C++ Programming Language. pp. 712]
+---
 
-I'm convinced that you could design a language about a tenth of the size of C++
-(whichever way you measure size) providing roughly what C++ does.
+> I'm convinced that you could design a language about a tenth of the size of C++
+> (whichever way you measure size) providing roughly what C++ does.
+>
+> &mdash; Masterminds of Programming: Conversations with the Creators of Major
+> Programming Languages, 2009-03-21
 
-[2009-03-21, Masterminds of Programming: Conversations with the Creators of
-Major Programming Languages]
+---
 
-Within C++, there is a much smaller and cleaner language struggling to get out.
+> Within C++, there is a much smaller and cleaner language struggling to get out.
+>
+> &mdash; The Design and Evolution of C++. pp. 207, Retrieved on 2007-11-15
 
-[Retrieved on 2007-11-15, The Design and Evolution of C++. pp. 207]
+---
 
-C makes it easy to shoot yourself in the foot; C++ makes it harder, but when you
-do it blows your whole leg off.
+> C makes it easy to shoot yourself in the foot; C++ makes it harder, but when you
+> do it blows your whole leg off.
+>
+> &mdash; Bjarne Stroustrup's FAQ: Did you really say that?, Retrieved on 2007-11-15
 
-[Retrieved on 2007-11-15, Bjarne Stroustrup's FAQ: Did you really say that?]
+---
 
-There are only two kinds of languages: the ones people complain about and the
-ones nobody uses.
-
-[Retrieved on 2007-11-15, Bjarne Stroustrup's FAQ: Did you really say that?]
+> There are only two kinds of languages: the ones people complain about and the
+> ones nobody uses.
+>
+> &mdash; Bjarne Stroustrup's FAQ: Did you really say that?, Retrieved on 2007-11-15

--- a/quotes/larry_wall.md
+++ b/quotes/larry_wall.md
@@ -1,6 +1,10 @@
-The three chief virtues of a programmer are: Laziness, Impatience and Hubris.
-[From the glossary of the first Programming Perl book]
+> The three chief virtues of a programmer are: Laziness, Impatience and Hubris.
+>
+> &mdash; From the glossary of the first Programming Perl book
 
-The problem with being consistent is that there are lots of ways to be
-consistent, and they're all inconsistent with each other.
-[http://www.nntp.perl.org/group/perl.perl6.language/21259]
+---
+
+> The problem with being consistent is that there are lots of ways to be
+> consistent, and they're all inconsistent with each other.
+>
+> &mdash; http://www.nntp.perl.org/group/perl.perl6.language/21259

--- a/quotes/linus_torvalds.md
+++ b/quotes/linus_torvalds.md
@@ -1,19 +1,23 @@
-I'm doing a (free) operating system (just a hobby, won't be big and professional
-like gnu) for 386(486) AT clones.
+> I'm doing a (free) operating system (just a hobby, won't be big and professional
+> like gnu) for 386(486) AT clones.
+>
+> &mdash; https://groups.google.com/g/comp.os.minix/c/dlNtH7RRrGA/m/SwRavCzVE7gJ, 1991-08-25
 
-[1991-08-25, https://groups.google.com/g/comp.os.minix/c/dlNtH7RRrGA/m/SwRavCzVE7gJ]
+---
 
-…git actually has a simple design, with stable and reasonably well-documented
-data structures. In fact, I'm a huge proponent of designing your code around the
-data, rather than the other way around, and I think it's one of the reasons git
-has been fairly successful […] I will, in fact, claim that the difference
-between a bad programmer and a good one is whether he considers his code or his
-data structures more important. Bad programmers worry about the code. Good
-programmers worry about data structures and their relationships.
+> …git actually has a simple design, with stable and reasonably well-documented
+> data structures. In fact, I'm a huge proponent of designing your code around the
+> data, rather than the other way around, and I think it's one of the reasons git
+> has been fairly successful […] I will, in fact, claim that the difference
+> between a bad programmer and a good one is whether he considers his code or his
+> data structures more important. Bad programmers worry about the code. Good
+> programmers worry about data structures and their relationships.
+>
+> &mdash; https://lwn.net/Articles/193245/, 2006-06-27
 
-[2006-06-27, https://lwn.net/Articles/193245/]
+---
 
-I'm an egotistical bastard, and I name all my projects after myself. First
-Linux, now git.
-
-[2007-06-14]
+> I'm an egotistical bastard, and I name all my projects after myself. First
+> Linux, now git.
+>
+> &mdash; 2007-06-14

--- a/quotes/martin_fowler.md
+++ b/quotes/martin_fowler.md
@@ -1,17 +1,24 @@
-Any fool can write code that a computer can understand. Good programmers write
-code that humans can understand.
+> Any fool can write code that a computer can understand. Good programmers write
+> code that humans can understand.
+>
+> &mdash; Refactoring: Improving the Design of Existing Code, 1999
 
-[1999, Refactoring: Improving the Design of Existing Code]
+---
 
-When you feel the need to write a comment, first try to refactor the code so
-that any comment becomes superfluous.
+> When you feel the need to write a comment, first try to refactor the code so
+> that any comment becomes superfluous.
+>
+> &mdash; Refactoring: Improving the Design of Existing Code, 1999
 
-[1999, Refactoring: Improving the Design of Existing Code]
+---
 
-Often designers do complicated things that improve the capacity on a particular
-hardware platform when it might actually be cheaper to buy more hardware.
+> Often designers do complicated things that improve the capacity on a particular
+> hardware platform when it might actually be cheaper to buy more hardware.
+>
+> &mdash; Patterns of Enterprise Application Architecture, 2012
 
-[2012, Patterns of Enterprise Application Architecture]
+---
 
-Comprehensiveness is the enemy of comprehensibility.
-[2004, UML Distilled: A Brief Guide to the Standard Object Modeling]
+> Comprehensiveness is the enemy of comprehensibility.
+>
+> &mdash; UML Distilled: A Brief Guide to the Standard Object Modeling, 2004


### PR DESCRIPTION
The quotes didn't look well formatted. Markdown has a feature for blockquotes
that is probably well-suited for this usecase. I've also switched to a different
style for attributions as well. This should help our quotes look more
professional. The before and after sections below show the difference:

### Before

Actually I made up the term "object-oriented", and I can tell you I did not have C++ in mind.

[1997, https://www.youtube.com/watch?v=oKg1hTOQXoY]

### After

> Actually I made up the term "object-oriented", and I can tell you I did not have
> C++ in mind.
>
> &mdash; https://www.youtube.com/watch?v=oKg1hTOQXoY, 1997